### PR TITLE
feat: support for multiple user-provided services

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ Check [`cds.log()`](https://cap.cloud.sap/docs/node.js/cds-log) for how to maint
 Your app must be bound to an instance of service `SAP Integration Suite, advanced event mesh` with plan `aem-validation-service`.
 Please see [Validation of VMR Provisioning](https://help.sap.com/docs/sap-integration-suite/advanced-event-mesh/validation-of-vmr-provisioning) for more information.
 
+In case your validation service is provided via a user-provided service instance (if it resides in a different sub account), you should tag it with `aem-validation-service` with the following command:
+
+```bash
+cf uups my-aem-validation-service -t "aem-validation-service"
+```
 
 ### Additional Configuration Options
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Finally, the broker's credentials must be provided via a [user-provided service 
 }
 ```
 
+In case your user-provided service instance has a different name (e.g. my-aem-broker), or you want to be able to test your application in hybrid mode using `cds bind`, you should tag your user-provided service with `advanced-event-mesh` with the following command:
+
+```bash
+cf uups my-aem-broker -t "advanced-event-mesh"
+```
+
 To troubleshoot connection issues, set log level for component `messaging` to `DEBUG`.
 Check [`cds.log()`](https://cap.cloud.sap/docs/node.js/cds-log) for how to maintain log levels.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Finally, the broker's credentials must be provided via a [user-provided service 
 }
 ```
 
-In case your user-provided service instance has a different name (e.g. my-aem-broker), or you want to be able to test your application in hybrid mode using `cds bind`, you should tag your user-provided service with `advanced-event-mesh` with the following command:
+In case your user-provided service instance has a different name (e.g. my-aem-broker), or you want to be able to test your application in hybrid mode using `cds bind`, you should tag your user-provided service with `advanced-event-mesh`. Either as a [mta.yaml resource parameter](https://help.sap.com/docs/btp/sap-business-technology-platform/service-tags), or with the following cli command:
 
 ```bash
 cf uups my-aem-broker -t "advanced-event-mesh"
@@ -96,7 +96,7 @@ Check [`cds.log()`](https://cap.cloud.sap/docs/node.js/cds-log) for how to maint
 Your app must be bound to an instance of service `SAP Integration Suite, advanced event mesh` with plan `aem-validation-service`.
 Please see [Validation of VMR Provisioning](https://help.sap.com/docs/sap-integration-suite/advanced-event-mesh/validation-of-vmr-provisioning) for more information.
 
-In case your validation service is provided via a user-provided service instance (if it resides in a different sub account), you should tag it with `aem-validation-service` with the following command:
+In case your validation service is provided via a user-provided service instance (if it resides in a different sub account), you should tag it with `aem-validation-service`. Either as a [mta.yaml resource parameter](https://help.sap.com/docs/btp/sap-business-technology-platform/service-tags), or with the following cli command:
 
 ```bash
 cf uups my-aem-validation-service -t "aem-validation-service"

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -161,7 +161,7 @@ module.exports = class AdvancedEventMesh extends cds.MessagingService {
     await super.init()
 
     const { uri, smf_uri } = _validateAndFetchEndpoints(this.options.credentials)
-    const mgmt_uri = uri + '/SEMP/v2/config'
+    const mgmt_uri = uri.endsWith('/SEMP/v2/config') ? uri : uri + '/SEMP/v2/config'
     await _validateBroker(mgmt_uri)
 
     this._eventAck = new EventEmitter() // for reliable messaging

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -33,7 +33,7 @@ const _getCredsFromVcap = test => {
 }
 
 const _validateAndFetchEndpoints = creds => {
-  const MSG = `Missing or malformed credentials for ${AEM}.\n\nBind your app to a user-provided service with name "advanced-event-mesh" and credentials in the following format:\n${UPS_FORMAT}`
+  const MSG = `Missing or malformed credentials for ${AEM}.\n\nBind your app to a user-provided service with name or tag "advanced-event-mesh" and credentials in the following format:\n${UPS_FORMAT}`
 
   if (!creds || !creds['authentication-service'] || !creds.endpoints || !creds.vpn) throw new Error(MSG)
 

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -25,9 +25,10 @@ const UPS_FORMAT = `{
 const _getCredsFromVcap = test => {
   const vcap = process.env.VCAP_SERVICES && JSON.parse(process.env.VCAP_SERVICES)
   if (!vcap) throw new Error('No VCAP_SERVICES in process environment')
-  for (const name in vcap) {
-    const srv = vcap[name][0]
-    if (test(srv)) return srv.credentials
+  for (const binding in vcap) {
+    for (const instance of vcap[binding]) {
+      if (test(instance)) return instance.credentials
+    }
   }
 }
 
@@ -84,7 +85,7 @@ function _fetchToken({ tokenendpoint, clientid, clientsecret, certificate: cert,
 
 const _validateBroker = async mgmt_uri => {
   // via VCAP_SERVICES to avoid specifying _another_ cds.requires service
-  const creds = _getCredsFromVcap(srv => srv.plan === 'aem-validation-service-plan')
+  const creds = _getCredsFromVcap(srv => (srv.plan === 'aem-validation-service-plan' || srv.tags.includes('aem-validation-service')))
 
   if (
     !creds ||

--- a/tests/simple/package.json
+++ b/tests/simple/package.json
@@ -12,8 +12,7 @@
           "customSessionOpt": true
         },
         "queue": {
-          "queueName": "testQueueName",
-          "customQueueOpt": true
+          "queueName": "testQueueName"
         },
         "consumer": {
           "customConsumerOpt": true

--- a/tests/simple/simple_unit.test.js
+++ b/tests/simple/simple_unit.test.js
@@ -266,7 +266,7 @@ describe('simple unit tests', () => {
       'https://foobar.messaging.solace.cloud:123/SEMP/v2/config/msgVpns/<vpn>/queues',
       {
         method: 'POST',
-        body: '{"permission":"consume","ingressEnabled":true,"egressEnabled":true,"customQueueOpt":true,"queueName":"testQueueName"}',
+        body: '{"permission":"consume","ingressEnabled":true,"egressEnabled":true,"queueName":"testQueueName"}',
         headers: {
           accept: 'application/json',
           'content-type': 'application/json',
@@ -292,7 +292,7 @@ describe('simple unit tests', () => {
       'https://foobar.messaging.solace.cloud:123/SEMP/v2/config/msgVpns/<vpn>/queues',
       {
         method: 'POST',
-        body: '{"permission":"consume","ingressEnabled":true,"egressEnabled":true,"customQueueOpt":true,"queueName":"testQueueName2"}',
+        body: '{"permission":"consume","ingressEnabled":true,"egressEnabled":true,"queueName":"testQueueName2"}',
         headers: {
           accept: 'application/json',
           'content-type': 'application/json',


### PR DESCRIPTION
It was expected that the broker credentials are provided via ups, and the validation service is a local service instance. In a scenario where the validation service is coming from a different subaccount (e.g. AEM deployed on a Shared Services subaccount and the CAP application in a separate project subaccount) you will have 2 user-provided services.

Changes proposed:
- The logic to fetch the credentials has to iterative over the bound user-provided services instead of checking the first one only. It also can look for a `tag` in addition to the `plan name`. This would close #38 as well.
- You can not rely on the `name` of a ups because `cds bind` on a ups results in `custom-service:` being prefixed to vcap names, so using `tags` is better, also making it more flexible for developers to choose the name of their service instance.

According to the referenced [docs](https://help.sap.com/docs/sap-integration-suite/advanced-event-mesh/cap-plugin-for-sap-integration-suite-advanced-event-mesh) to create the ups, at the very bottom the `uri` field is documented to be in the format `https://xxxxxxx-xxxxxxx-xxxxxxxx.messaging.solace.cloud:<port>/SEMP/v2/config`, while the ups example (as well as the readme of this plugin) mentions the format `https://<broker host>:<port>`. It can create confusion whether to add the `/SEMP/v2/config` suffix to the ups or not, so the plugin should support both versions.

Changes proposed:
- Append `/SEMP/v2/config` only when not yet part of the uri

The *simple test* application uses config parameter `customQueueOpt`. This is not documented in [SEMP](https://docs.solace.com/API-Developer-Online-Ref-Documentation/swagger-ui/software-broker/config/index.html#/msgVpn/createMsgVpnQueue) and generates an error, so it has been removed.