### PR TITLE
Fix: Parse as text for non-binary payload

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -294,7 +294,13 @@ module.exports = class AdvancedEventMesh extends cds.MessagingService {
     this.messageConsumer.on(solace.MessageConsumerEventName.MESSAGE, async message => {
       const event = message.getDestination().getName()
       if (this.LOG._info) this.LOG.info('Received message', event)
-      const msg = normalizeIncomingMessage(message.getBinaryAttachment())
+      let payload
+      if (message.getType() == solace.MessageType.TEXT) {
+        payload = message.getSdtContainer().getValue()
+      } else {
+        payload = message.getBinaryAttachment()
+      }
+      const msg = normalizeIncomingMessage(payload)
       msg.event = event
       try {
         // NOTE: processInboundMsg doesn't exist in cds^8


### PR DESCRIPTION
When using tools such as Postman or curl to send events to AEM, payload is sent as normal text/json and not as binary. So on the receiver side (plugin) it has to be treated as such. See https://community.solace.com/t/weird-chars-at-start-of-text-payload/1856.

When using getBinaryAttachment() on a string payload, you will get the following:
```
Sending:
{ "foo":"bar" }

Receiving:
" N{ \"foo\":\"bar\" }"
```

With 2 invalid characters in the beginning, which are payload-length identifiers from the Structured Data Type (SDT) formatted message.