### PR TITLE
Fix: Remove invalid parameter

### DIFF
--- a/tests/simple/package.json
+++ b/tests/simple/package.json
@@ -12,8 +12,7 @@
           "customSessionOpt": true
         },
         "queue": {
-          "queueName": "testQueueName",
-          "customQueueOpt": true
+          "queueName": "testQueueName"
         },
         "consumer": {
           "customConsumerOpt": true

--- a/tests/simple/simple_unit.test.js
+++ b/tests/simple/simple_unit.test.js
@@ -266,7 +266,7 @@ describe('simple unit tests', () => {
       'https://foobar.messaging.solace.cloud:123/SEMP/v2/config/msgVpns/<vpn>/queues',
       {
         method: 'POST',
-        body: '{"permission":"consume","ingressEnabled":true,"egressEnabled":true,"customQueueOpt":true,"queueName":"testQueueName"}',
+        body: '{"permission":"consume","ingressEnabled":true,"egressEnabled":true,"queueName":"testQueueName"}',
         headers: {
           accept: 'application/json',
           'content-type': 'application/json',
@@ -292,7 +292,7 @@ describe('simple unit tests', () => {
       'https://foobar.messaging.solace.cloud:123/SEMP/v2/config/msgVpns/<vpn>/queues',
       {
         method: 'POST',
-        body: '{"permission":"consume","ingressEnabled":true,"egressEnabled":true,"customQueueOpt":true,"queueName":"testQueueName2"}',
+        body: '{"permission":"consume","ingressEnabled":true,"egressEnabled":true,"queueName":"testQueueName2"}',
         headers: {
           accept: 'application/json',
           'content-type': 'application/json',


### PR DESCRIPTION
The simple test application uses config parameter customQueueOpt. This is not documented in [SEMP](https://docs.solace.com/API-Developer-Online-Ref-Documentation/swagger-ui/software-broker/config/index.html#/msgVpn/createMsgVpnQueue) and generates an error.

```bash
[advanced-event-mesh] - Error: Queue "testQueueName" could not be created
    at AdvancedEventMesh._createQueueM (/Users/i069808/Software/aem-ai-microservice/node_modules/@cap-js/advanced-event-mesh/cds-plugin.js:389:21)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async AdvancedEventMesh.startListening (/Users/i069808/Software/aem-ai-microservice/node_modules/@cap-js/advanced-event-mesh/cds-plugin.js:311:7) {
  code: 'CREATE_QUEUE_FAILED',
  target: { kind: 'QUEUE', queue: 'testQueueName' },
  reason: {
    code: 11,
    description: "Unknown attribute 'customQueueOpt'",
    status: 'INVALID_PARAMETER'
  }
}
```