### PR TITLE
test: increase beforeAll timeout for CI stability

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
     "lint": "npx eslint .",
     "test": "npx jest --silent"
   },
-  "jest": {
-    "testTimeout": 30000
-  },
   "dependencies": {
     "@sap/xb-msg-amqp-v100": "*",
     "solclientjs": "^10.17.1"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "lint": "npx eslint .",
     "test": "npx jest --silent"
   },
+  "jest": {
+    "testTimeout": 30000
+  },
   "dependencies": {
     "@sap/xb-msg-amqp-v100": "*",
     "solclientjs": "^10.17.1"

--- a/tests/simple/simple_unit.test.js
+++ b/tests/simple/simple_unit.test.js
@@ -1,6 +1,9 @@
 const cds = require('@sap/cds')
 cds.test.in(__dirname)
 
+// Set global Jest timeout for this test file
+jest.setTimeout(30000)
+
 const DATA = { key1: 1, value1: 1 }
 const MUST_FAIL = { mustFail: true, value1: 1 }
 const MUST_REJECT = { mustReject: true, value1: 1 }
@@ -133,7 +136,7 @@ describe('simple unit tests', () => {
 
   beforeAll(async () => {
     messaging = await cds.connect.to('messaging')
-  })
+  }, 30000)
 
   test('emit from app service', async () => {
     await messaging.emit('foo', DATA, HEADERS)

--- a/tests/simple/simple_unit.test.js
+++ b/tests/simple/simple_unit.test.js
@@ -1,9 +1,6 @@
 const cds = require('@sap/cds')
 cds.test.in(__dirname)
 
-// Set global Jest timeout for this test file
-jest.setTimeout(30000)
-
 const DATA = { key1: 1, value1: 1 }
 const MUST_FAIL = { mustFail: true, value1: 1 }
 const MUST_REJECT = { mustReject: true, value1: 1 }


### PR DESCRIPTION
## Summary
- Increase beforeAll hook timeout from 5s to 30s to prevent CI pipeline timeouts during messaging connection setup