### PR TITLE
chore(ci): add `--ignore-scripts` to all install steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
-      - run: npm i
-      - run: if [ ${{ matrix.cds-version }} -eq 8 ]; then npm i -f @sap/cds@8 @cap-js/sqlite@1; fi
+      - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }} --ignore-scripts
+      - run: npm i --ignore-scripts
+      - run: if [ ${{ matrix.cds-version }} -eq 8 ]; then npm i -f @sap/cds@8 @cap-js/sqlite@1 --ignore-scripts; fi
       - run: cds v
       - run: npm run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: run tests
         run: |
-          npm i -g @sap/cds-dk
-          npm i
+          npm i -g @sap/cds-dk --ignore-scripts
+          npm i --ignore-scripts
           npm run lint
           npm run test
       - name: get version


### PR DESCRIPTION
# Add `--ignore-scripts` to All CI Install Steps

### Chore

🔧 Added the `--ignore-scripts` flag to all `npm install` commands across CI and release workflows to prevent execution of lifecycle scripts during dependency installation, improving security and predictability of the CI pipeline.

### Changes

* `.github/workflows/ci.yml`: Updated all three `npm i` steps (global `@sap/cds-dk` install, local install, and the conditional CDS v8 install) to include `--ignore-scripts`.
* `.github/workflows/release.yml`: Updated the `npm i -g @sap/cds-dk` and `npm i` commands in the release workflow's test step to include `--ignore-scripts`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- Event Trigger: `pull_request.opened`
- Correlation ID: `a7939b51-54cd-4c9b-9839-f2416c7f6b5f`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
